### PR TITLE
Fix database issues from PED

### DIFF
--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -18,10 +18,10 @@ public class Duke {
                         "`------'`------'`------'`------'`------'`------'`------'`------'`------'`------'\n";
 
         System.out.println("Hello from\n" + logo);
-        System.out.println("What is your name?");
+        System.out.println("Start splitting your expenses now!");
 
         Scanner in = new Scanner(System.in);
-        System.out.println("Hello " + in.nextLine());
+
         Help.printHelp();
 
         while(in.hasNextLine()) {

--- a/src/main/java/seedu/duke/Expense.java
+++ b/src/main/java/seedu/duke/Expense.java
@@ -3,6 +3,7 @@ package seedu.duke;
 
 
 import seedu.duke.exceptions.ExpensesException;
+import seedu.duke.storage.GroupStorage;
 
 import java.util.ArrayList;
 
@@ -81,12 +82,14 @@ public class Expense {
     }
 
     void printSuccessMessage() {
-        System.out.printf("Added new expense with description %s and amount %.2f paid by %s and split between:\n",
-                this.description, this.totalAmount, this.payerName);
-        for (Pair<String, Float> payee : payees) {
-            System.out.printf("%s who owes %.2f\n", payee.getKey(), payee.getValue());
+        if (!GroupStorage.isLoading) {
+            System.out.println("Added new expense with description " + description + " and amount " + totalAmount
+                    + " paid by " + payerName + " and split between:");
+            for (Pair<String, Float> payee : payees) {
+                System.out.println(payee.getKey() + " who owes " + String.format("%.2f", payee.getValue()));
+            }
+            System.out.println();
         }
-        System.out.println();
     }
 
     public String getPayer() {

--- a/src/main/java/seedu/duke/Group.java
+++ b/src/main/java/seedu/duke/Group.java
@@ -162,7 +162,7 @@ public class Group {
      */
     public static boolean isMember(String memberName) {
         for (User member : members) {
-            if (member.getName().equals(memberName)) {
+            if (member.getName().equalsIgnoreCase(memberName)) {
                 return true;
             }
         }

--- a/src/main/java/seedu/duke/Group.java
+++ b/src/main/java/seedu/duke/Group.java
@@ -188,7 +188,9 @@ public class Group {
 
         User newMember = new User(memberName);
         members.add(newMember);
-        System.out.println(memberName + " has been added to " + groupName + ".");
+        if (!GroupStorage.isLoading) {
+            System.out.println(memberName + " has been added to " + groupName + ".");
+        }
         return newMember;
     }
 

--- a/src/main/java/seedu/duke/Group.java
+++ b/src/main/java/seedu/duke/Group.java
@@ -41,6 +41,7 @@ public class Group {
      * @return The existing or newly created group.
      * @throws IllegalStateException If trying to create or join a new group while already in another group.
      */
+    //@@ author avrilgk
     public static Optional<Group> getOrCreateGroup(String groupName) {
 
         // Check if group name is empty
@@ -49,16 +50,13 @@ public class Group {
             return Optional.empty();
         }
 
-        // Check if user is accessing a group they are already in
-        getCurrentGroup().ifPresent(currentGroup -> {
-            if (currentGroup.getGroupName().equals(groupName)) {
-                System.out.println("You are already in " + groupName);
-            }
-        });
-
-
-
         Optional<Group> group = Optional.ofNullable(groups.get(groupName));
+
+        // Check if user is accessing a group they are already in
+        if (group.isPresent() && getCurrentGroup().isPresent() && getCurrentGroup().get().equals(group.get())) {
+            System.out.println("You are already in " + groupName);
+            return Optional.empty();
+        }
 
         // Create a new group if it doesn't exist
         if (group.isEmpty() && !groupNameChecker.doesGroupNameExist(groupName)) {
@@ -67,12 +65,11 @@ public class Group {
             System.out.println(groupName + " created.");
             currentGroupName = Optional.of(groupName);
             group = Optional.of(newGroup);
+            System.out.println("You are now in " + groupName);
         } else if (groupNameChecker.doesGroupNameExist(groupName)) {
             System.out.println("Group already exists. Use 'enter " + groupName + "' to enter the group.");
             return Optional.empty();
         }
-
-        System.out.println("You are now in " + groupName);
 
         assert group.isPresent() : "Group should be created and present";
         assert currentGroupName.isPresent() : "Current group name should be set";

--- a/src/main/java/seedu/duke/Group.java
+++ b/src/main/java/seedu/duke/Group.java
@@ -105,7 +105,7 @@ public class Group {
                 }
                 // @@author hafizuddin-a
             } catch (GroupLoadException e) {
-                System.out.println("Error loading group: " + e.getMessage());
+                System.out.println("Group does not exist.");
                 return Optional.empty();
             }
         }

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -129,7 +129,9 @@ public class Parser {
     public void handleUserInput() throws EndProgramException, ExpensesException {
         switch (command) {
         case "bye":
-            GroupCommand.exitGroup();
+            if (Group.isInGroup()) {
+                GroupCommand.exitGroup();
+            }
             throw new EndProgramException();
         case "help":
             // Help code here

--- a/src/main/java/seedu/duke/storage/GroupStorage.java
+++ b/src/main/java/seedu/duke/storage/GroupStorage.java
@@ -19,6 +19,8 @@ import java.util.List;
  * Handles the saving and loading of group information to and from files.
  */
 public class GroupStorage {
+    public static boolean isLoading = false;
+
     private static final String MEMBERS_HEADER = "Members:";
     private static final String EXPENSES_HEADER = "Expenses:";
     private static final String EXPENSE_DELIMITER = ",";
@@ -121,6 +123,7 @@ public class GroupStorage {
      * @throws GroupLoadException if an error occurs while loading the group information
      */
     public Group loadGroupFromFile(String groupName) throws GroupLoadException {
+        isLoading = true;
         try {
             String filePath = GroupFilePath.getFilePath(groupName);
             BufferedReader reader = fileIO.getFileReader(filePath);
@@ -134,6 +137,7 @@ public class GroupStorage {
             loadExpenses(reader, group);
 
             reader.close();
+            isLoading = false;
             return group;
         } catch (IOException e) {
             throw new GroupLoadException("An error occurred while loading the group: " + e.getMessage());

--- a/src/main/java/seedu/duke/storage/GroupStorage.java
+++ b/src/main/java/seedu/duke/storage/GroupStorage.java
@@ -137,12 +137,13 @@ public class GroupStorage {
             loadExpenses(reader, group);
 
             reader.close();
-            isLoading = false;
             return group;
         } catch (IOException e) {
             throw new GroupLoadException("An error occurred while loading the group: " + e.getMessage());
         } catch (Exception e) {
             throw new GroupLoadException("An unexpected error occurred while loading the group: " + e.getMessage());
+        } finally {
+            isLoading = false;
         }
     }
 


### PR DESCRIPTION
- removed asking user for name feature as it caused a lot of confusion as per issue #144 #102 . please note this change or feel free to add back if needed
- added isLoading flag in Group and Expense classes to prevent printing of add expense/member messages when loading a saved group. for @mukund1403 @avrilgk to note
- improved logic flow of getOrCreateGroup to ensure proper loading of group and prevent duplicate messages. for @avrilgk to review. refer to commit [Fix double message group bug](https://github.com/AY2324S2-CS2113-T15-3/tp/pull/154/commits/34529e3ca080042363050be38ff0db168c95c78a) for improvements
- resolves issues #102 , #109 , #119 , #123 , #126 ,  #144